### PR TITLE
PROJ-2832: Create synthetic feeder

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Functionality is implemented on the NetworkConsumerClient from the Evolve SDK, s
     
 The `usage_point_proportional_allocator` function creates an allocator that distributes NMI names across a percentage
 of usage points. It will use up all provided names before reusing any. In other words, it will not reuse a name unless
-the number of modifications (`num_allocations`) is greater than the length of `edith_customers`.
+the number of allocations (`num_allocations`) is greater than the length of `edith_customers`.
 
 Example: A synthetic feeder is created on a feeder with 5 usage points: UP1, UP2, UP3, UP4, and UP5. The allocator is
 a `usage_point_proportional_allocator(proportion=60, edith_customers=["A", "B", "C"])`. One possible result of the

--- a/README.md
+++ b/README.md
@@ -13,7 +13,21 @@ Functionality is implemented on the NetworkConsumerClient from the evolve SDK, s
     
     channel = connect_with_password(client_id="some_client_id", username="test", password="secret", host="host", port=443)
     client = NetworkConsumerClient(channel)
-    allocator = distribution_transformer_proportional_allocator_creator(proportion=30, edith_customers=["9995435452"])
-    synthetic_feeder = client.create_synthetic_feeder("some_feeder_mrid", allocator=allocator)
+    allocator = usage_point_proportional_allocator(proportion=30, edith_customers=["9995435452"])
+    synthetic_feeder, num_allocations = client.create_synthetic_feeder(
+        "some_feeder_mrid",
+        allocator=allocator,
+        seed=1234  # exclude for non-deterministic allocation
+    )
     # ... do stuff with synthetic feeder ...
     
+The `usage_point_proportional_allocator` function creates an allocator that distributes NMI names across a percentage
+of usage points. It will use up all provided names before reusing any. In other words, it will not reuse a name unless
+the number of modifications (`num_allocations`) is greater than the length of `edith_customers`.
+
+Example: A synthetic feeder is created on a feeder with 5 usage points: UP1, UP2, UP3, UP4, and UP5. The allocator is
+a `usage_point_proportional_allocator(proportion=60, edith_customers=["A", "B", "C"])`. One possible result of the
+allocation is for UP5 to receive name "A", UP2 to receive name "B", and UP3 to receive name "C". UP1 and UP4 would not
+be modified in this case.
+
+The `seed` parameter is used to seed the pseudorandom number generator, making the random allocations reproducible.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Functionality is implemented on the NetworkConsumerClient from the Evolve SDK, s
     
     channel = connect_with_password(client_id="some_client_id", username="test", password="secret", host="host", port=443)
     client = NetworkConsumerClient(channel)
-    allocator = usage_point_proportional_allocator(proportion=30, edith_customers=["9995435452"])
+    allocator = usage_point_proportional_allocator(
+        proportion=30,
+        edith_customers=["9995435452"],
+        allow_duplicate_customers=True  # exclude to prevent adding a customer to multiple usage points
+    )
     synthetic_feeder, num_allocations = client.create_synthetic_feeder(
         "some_feeder_mrid",
         allocator=allocator,
@@ -23,7 +27,9 @@ Functionality is implemented on the NetworkConsumerClient from the Evolve SDK, s
     
 The `usage_point_proportional_allocator` function creates an allocator that distributes NMI names across a percentage
 of usage points. It will use up all provided names before reusing any. In other words, it will not reuse a name unless
-the number of allocations (`num_allocations`) is greater than the length of `edith_customers`.
+the number of allocations (`num_allocations`) is greater than the length of `edith_customers`. By default, it will stop
+allocating NMI names once it uses up all provided names, unless `allow_duplicate_customers` is set to `True`.
+This allocator also removes an existing NMI on each usage point it adds a NMI to, if there exists one.
 
 Example: A synthetic feeder is created on a feeder with 5 usage points: UP1, UP2, UP3, UP4, and UP5. The allocator is
 a `usage_point_proportional_allocator(proportion=60, edith_customers=["A", "B", "C"])`. One possible result of the

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and apply certain scenarios to them to modify the network.
 
 # Usage #
 
-Functionality is implemented on the NetworkConsumerClient from the evolve SDK, so to use simply do the following:
+Functionality is implemented on the NetworkConsumerClient from the Evolve SDK, so to use simply do the following:
 
     from zepben.edith import NetworkConsumerClient, connect_with_password, distribution_transformer_proportional_allocator_creator
     

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 from setuptools import setup, find_namespace_packages
 
 deps = [
-    "zepben.evolve==0.33.0b4",
+    "zepben.evolve==0.33.0b5",
     "dataclassy==0.6.2",
 ]
 

--- a/src/zepben/edith/__init__.py
+++ b/src/zepben/edith/__init__.py
@@ -4,20 +4,23 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import itertools
+import logging
 import random
 from asyncio import get_event_loop
 from zepben.evolve import *
 from zepben.protobuf.nc.nc_requests_pb2 import INCLUDE_ENERGIZED_LV_FEEDERS
 
+logger = logging.getLogger("zepben.edith")
+
 
 def do_nothing_allocator(_1, _2):
-    pass
+    return 0
 
 
 def distribution_transformer_proportional_allocator_creator(
         proportion: int,
         edith_customers: List[str]
-) -> Callable[[LvFeeder], None]:
+) -> Callable[[LvFeeder, NameType], int]:
     """
     Creates an allocator for the synthetic feeder creator that distributes a `proportion` of NMIs from `edith_customers`
     to an `LvFeeder`
@@ -31,17 +34,28 @@ def distribution_transformer_proportional_allocator_creator(
         raise ValueError("Proportion must be between 1 and 100")
 
     nmi_generator = itertools.cycle(edith_customers)
+    num_nmis_used = 0
 
-    def allocator(lv_feeder: LvFeeder, nmi_name_type: NameType):
+    def allocator(lv_feeder: LvFeeder, nmi_name_type: NameType) -> int:
+        nonlocal num_nmis_used
+
         usage_points = []
         for eq in lv_feeder.equipment:
             usage_points.extend(eq.usage_points)
-
         usage_points.sort(key=lambda up: up.mrid)
 
-        for up in random.sample(usage_points, int(len(usage_points) * proportion/100)):
+        usage_points_to_name = random.sample(usage_points, int(len(usage_points) * proportion / 100))
+        if num_nmis_used <= len(edith_customers) < num_nmis_used + len(usage_points_to_name):
+            logger.warning(
+                "Insufficient NMIs to allocate to the requested percentage of usage points without repetition."
+            )
+        num_nmis_used += len(usage_points_to_name)
+
+        for up in usage_points_to_name:
             # noinspection PyArgumentList
             up.add_name(nmi_name_type.get_or_add_name(next(nmi_generator), up))
+
+        return len(usage_points_to_name)
 
     return allocator
 
@@ -49,7 +63,7 @@ def distribution_transformer_proportional_allocator_creator(
 async def _create_synthetic_feeder(
         self: NetworkConsumerClient,
         feeder_mrid: str,
-        allocator: Callable[[LvFeeder, NameType], None] = do_nothing_allocator,
+        allocator: Callable[[LvFeeder, NameType], int] = do_nothing_allocator,
         seed: Optional[int] = None
 ) -> NetworkService:
     """
@@ -72,8 +86,11 @@ async def _create_synthetic_feeder(
     if seed:
         random.seed(seed)
 
+    total_allocated = 0
     for lv_feeder in sorted(feeder_network.objects(LvFeeder), key=lambda lvf: lvf.mrid):
-        allocator(lv_feeder, nmi_name_type)
+        total_allocated += allocator(lv_feeder, nmi_name_type)
+
+    logger.info(f"NMI names have been added to {total_allocated} usage points.")
 
     return feeder_network
 
@@ -83,7 +100,7 @@ NetworkConsumerClient.create_synthetic_feeder = _create_synthetic_feeder
 def _sync_create_synthetic_feeder(
         self: SyncNetworkConsumerClient,
         feeder_mrid: str,
-        allocator: Callable[[LvFeeder, NameType], None] = do_nothing_allocator,
+        allocator: Callable[[LvFeeder, NameType], int] = do_nothing_allocator,
         seed: Optional[int] = None
 ) -> NetworkService:
     return get_event_loop().run_until_complete(_create_synthetic_feeder(self, feeder_mrid, allocator, seed))

--- a/src/zepben/edith/__init__.py
+++ b/src/zepben/edith/__init__.py
@@ -39,7 +39,7 @@ def distribution_transformer_proportional_allocator_creator(
 
         for up in random.sample(usage_points, int(len(usage_points) * 1/proportion)):
             # noinspection PyArgumentList
-            up.add_name(Name(name=next(nmi_generator), type=nmi_name_type))
+            up.add_name(nmi_name_type.get_or_add_name(next(nmi_generator), up))
 
     return allocator
 

--- a/src/zepben/edith/__init__.py
+++ b/src/zepben/edith/__init__.py
@@ -60,7 +60,7 @@ async def _create_synthetic_feeder(
 
     :param feeder_mrid: The mRID of the feeder to create a synthetic version.
     :param allocator: The allocator to use to modify the LvFeeders. Default will do nothing to the feeder.
-    :return: 2-tuple of (the synthetic version of the NetworkService, the number of modified identified objects)
+    :return: 2-tuple of (the synthetic version of the NetworkService, the number of added identified objects)
     """
 
     await self.get_equipment_container(feeder_mrid, Feeder, include_energized_containers=INCLUDE_ENERGIZED_LV_FEEDERS)

--- a/src/zepben/edith/__init__.py
+++ b/src/zepben/edith/__init__.py
@@ -40,9 +40,9 @@ def usage_point_proportional_allocator(
 
         usage_points_to_name = random.sample(usage_points, int(len(usage_points) * proportion / 100))
 
-        for up in usage_points_to_name:
+        for usage_point in usage_points_to_name:
             # noinspection PyArgumentList
-            up.add_name(nmi_name_type.get_or_add_name(next(nmi_generator), up))
+            usage_point.add_name(nmi_name_type.get_or_add_name(next(nmi_generator), usage_point))
 
         return len(usage_points_to_name)
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,0 @@
-#  Copyright 2021 Zeppelin Bend Pty Ltd
-#
-#  This Source Code Form is subject to the terms of the Mozilla Public
-#  License, v. 2.0. If a copy of the MPL was not distributed with this
-#  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,4 +4,4 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from .network_fixtures import *
+from network_fixtures import *

--- a/test/streaming/get/test_edith.py
+++ b/test/streaming/get/test_edith.py
@@ -21,8 +21,8 @@ from zepben.protobuf.nc.nc_responses_pb2 import GetIdentifiedObjectsResponse, Ge
     GetNetworkHierarchyResponse
 
 from zepben.edith import NetworkConsumerClient, usage_point_proportional_allocator
-from test.streaming.get.grpcio_aio_testing.mock_async_channel import async_testing_channel
-from test.streaming.get.mock_server import MockServer, StreamGrpc, UnaryGrpc, unary_from_fixed
+from streaming.get.grpcio_aio_testing.mock_async_channel import async_testing_channel
+from streaming.get.mock_server import MockServer, StreamGrpc, UnaryGrpc, unary_from_fixed
 
 
 class TestNetworkConsumer:

--- a/test/streaming/get/test_edith.py
+++ b/test/streaming/get/test_edith.py
@@ -10,24 +10,27 @@ import pytest
 
 import grpc_testing
 from zepben.evolve import NetworkService, IdentifiedObject, CableInfo, AcLineSegment, Breaker, EnergySource, \
-    EnergySourcePhase, Junction, PowerTransformer, PowerTransformerEnd, ConnectivityNode, Feeder, Location, OverheadWireInfo, PerLengthSequenceImpedance, \
+    EnergySourcePhase, Junction, PowerTransformer, PowerTransformerEnd, ConnectivityNode, Feeder, Location, \
+    OverheadWireInfo, PerLengthSequenceImpedance, \
     Substation, Terminal, EquipmentContainer, TransformerStarImpedance, GeographicalRegion, \
     SubGeographicalRegion, Circuit, Loop, LvFeeder, UsagePoint, BaseVoltage
 from zepben.protobuf.nc import nc_pb2
 from zepben.protobuf.nc.nc_data_pb2 import NetworkIdentifiedObject
 from zepben.protobuf.nc.nc_requests_pb2 import GetIdentifiedObjectsRequest, GetEquipmentForContainersRequest
-from zepben.protobuf.nc.nc_responses_pb2 import GetIdentifiedObjectsResponse, GetEquipmentForContainersResponse, GetNetworkHierarchyResponse
+from zepben.protobuf.nc.nc_responses_pb2 import GetIdentifiedObjectsResponse, GetEquipmentForContainersResponse, \
+    GetNetworkHierarchyResponse
 
 from zepben.edith import NetworkConsumerClient, usage_point_proportional_allocator
 from test.streaming.get.grpcio_aio_testing.mock_async_channel import async_testing_channel
-from test.streaming.get.mock_server import MockServer, StreamGrpc, UnaryGrpc, stream_from_fixed, unary_from_fixed
+from test.streaming.get.mock_server import MockServer, StreamGrpc, UnaryGrpc, unary_from_fixed
 
 
 class TestNetworkConsumer:
 
     @pytest.fixture(autouse=True)
     def setup(self):
-        self.channel = async_testing_channel(nc_pb2.DESCRIPTOR.services_by_name.values(), grpc_testing.strict_real_time())
+        self.channel = async_testing_channel(nc_pb2.DESCRIPTOR.services_by_name.values(),
+                                             grpc_testing.strict_real_time())
         self.mock_server = MockServer(self.channel, nc_pb2.DESCRIPTOR.services_by_name['NetworkConsumer'])
         self.client = NetworkConsumerClient(channel=self.channel)
         self.service = self.client.service
@@ -36,8 +39,6 @@ class TestNetworkConsumer:
     @pytest.mark.parametrize("feeder_network", [5], indirect=True)
     async def test_create_synthetic_feeder(self, feeder_network: NetworkService):
         feeder_mrid = "f001"
-
-        # TODO: uncomment everything here after getting feeder is actually implemented otherwise it just hangs
 
         async def client_test():
             service, n = await self.client.create_synthetic_feeder(
@@ -52,12 +53,13 @@ class TestNetworkConsumer:
 
         object_responses = _create_object_responses(feeder_network)
 
-        await self.mock_server.validate(client_test,
-                                        [
-                                            UnaryGrpc('getNetworkHierarchy', unary_from_fixed(None, _create_hierarchy_response(feeder_network))),
-                                            StreamGrpc('getEquipmentForContainers', [_create_container_responses(feeder_network)]),
-                                            StreamGrpc('getIdentifiedObjects', [object_responses, object_responses])
-                                        ])
+        await self.mock_server.validate(
+            client_test,
+            [
+                UnaryGrpc('getNetworkHierarchy', unary_from_fixed(None, _create_hierarchy_response(feeder_network))),
+                StreamGrpc('getEquipmentForContainers', [_create_container_responses(feeder_network)]),
+                StreamGrpc('getIdentifiedObjects', [object_responses, object_responses])
+            ])
 
 
 # noinspection PyUnresolvedReferences
@@ -116,7 +118,7 @@ def _response_of(io: IdentifiedObject, response_type):
 
 
 def _create_object_responses(ns: NetworkService, mrids: Optional[Iterable[str]] = None) \
-    -> Callable[[GetIdentifiedObjectsRequest], Generator[GetIdentifiedObjectsResponse, None, None]]:
+        -> Callable[[GetIdentifiedObjectsRequest], Generator[GetIdentifiedObjectsResponse, None, None]]:
     valid: Dict[str, IdentifiedObject] = {mrid: ns[mrid] for mrid in mrids} if mrids else ns
 
     def responses(request: GetIdentifiedObjectsRequest) -> Generator[GetIdentifiedObjectsResponse, None, None]:
@@ -143,10 +145,11 @@ def _create_hierarchy_response(service: NetworkService) -> GetNetworkHierarchyRe
 
 
 def _create_container_responses(ns: NetworkService, mrids: Optional[Iterable[str]] = None) \
-    -> Callable[[GetEquipmentForContainersRequest], Generator[GetEquipmentForContainersResponse, None, None]]:
+        -> Callable[[GetEquipmentForContainersRequest], Generator[GetEquipmentForContainersResponse, None, None]]:
     valid: Dict[str, EquipmentContainer] = {mrid: ns[mrid] for mrid in mrids} if mrids else ns
 
-    def responses(request: GetEquipmentForContainersRequest) -> Generator[GetEquipmentForContainersResponse, None, None]:
+    def responses(request: GetEquipmentForContainersRequest) -> \
+            Generator[GetEquipmentForContainersResponse, None, None]:
         for mrid in request.mrids:
             container = valid[mrid]
             if container:


### PR DESCRIPTION
# Description

Implements create_synthetic_feeder extension for both the sync and async network consumer clients. This uses an allocator function to add NMI names to usage points. Also implements one such allocator that randomly allocated from a provided list of NMI names to a percentage of usage points. The task is https://app.clickup.com/t/6929263/PROJ-2832.

# Associated tasks:

This is a subtask of https://app.clickup.com/t/6929263/PROJ-2830.

Tasks blocking this one:
- [x] Merge https://github.com/zepben/evolve-sdk-python/pull/111

Tasks this is blocking:
- None

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have updated any documentation required for these changes.
- [x] I have handled all new warnings generated by the compiler or IDE.
