### PR TITLE
EWB-2543: Update sdk version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 * None.
 
 ### New Features
-* None.
+* Added support for SDK 0.35.0
 
 ### Enhancements
 * None.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 from setuptools import setup, find_namespace_packages
 
 deps = [
-    "zepben.evolve==0.35.0b2",
+    "zepben.evolve==0.35.0b4",
     "dataclassy==0.6.2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 from setuptools import setup, find_namespace_packages
 
 deps = [
-    "zepben.evolve==0.35.0b6",
+    "zepben.evolve==0.35.0b7",
     "dataclassy==0.6.2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 from setuptools import setup, find_namespace_packages
 
 deps = [
-    "zepben.evolve==0.35.0b4",
+    "zepben.evolve==0.35.0b5",
     "dataclassy==0.6.2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 from setuptools import setup, find_namespace_packages
 
 deps = [
-    "zepben.evolve==0.35.0b5",
+    "zepben.evolve==0.35.0b6",
     "dataclassy==0.6.2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 from setuptools import setup, find_namespace_packages
 
 deps = [
-    "zepben.evolve==0.34.0",
+    "zepben.evolve==0.35.0b2",
     "dataclassy==0.6.2",
 ]
 


### PR DESCRIPTION
Signed-off-by: Marcus Koh <marcus.koh@zepben.com>

# Description

Simple update to sdk version to avoid conflict in ewb examples repo.

# Associated tasks:

Tasks blocking this one:
- [x] https://github.com/zepben/evolve-sdk-python/pull/116
- [x] https://github.com/zepben/evolve-sdk-python/pull/115
- [x] https://github.com/zepben/evolve-sdk-python/pull/118
- [x] https://github.com/zepben/evolve-sdk-python/pull/119
- [x] https://github.com/zepben/evolve-sdk-python/pull/120

Tasks this is blocking:
- https://github.com/zepben/ewb-sdk-examples-python/pull/2

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have updated the changelog.
