### PR TITLE
EWB-3140: Update SDK version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 from setuptools import setup, find_namespace_packages
 
 deps = [
-    "zepben.evolve==0.35.0b7",
+    "zepben.evolve==0.35.0b9",
     "dataclassy==0.6.2",
 ]
 


### PR DESCRIPTION
Signed-off-by: Marcus Koh <marcus.koh@zepben.com>

# Description

Another update to the Evolve SDK dependency version to resolve a dependency conflict.

# Associated tasks:

Tasks blocking this one:
- [x] https://github.com/zepben/evolve-sdk-python/pull/123

Tasks this is blocking:
- https://github.com/zepben/ewb-sdk-examples-python/pull/3

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary. (No tests needed for an SDK update)
- [x] I have updated the changelog. (no change needed, SDK version update is within the same minor version)
- [x] I have handled all new warnings generated by the compiler or IDE.
